### PR TITLE
Add cmake for better compiling process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+Makefile
+SyobonAction
+CMakeCache.txt
+CMakeFiles/
+CMakeLists.txt
+cmake_install.cmake

--- a/DxLib.cpp
+++ b/DxLib.cpp
@@ -1,4 +1,5 @@
 #include "DxLib.h"
+#include <locale.h>
 
 SDL_Joystick* joystick;
 

--- a/README.md
+++ b/README.md
@@ -89,3 +89,9 @@ Release Changelog
 
 **Open Syobon Action v0.8:**
 * First release
+
+**Compile with CMake**
+```shell
+$ cmake .
+$ make
+```


### PR DESCRIPTION
The compiling process on OS X is weird due to Apple's change on tool chains(see [here](https://github.com/andlabs/libui/issues/422)), so I add a cmake file to help compile it.
```shell
$ cmake .
$ make
```